### PR TITLE
Fix the import and export commands (issue #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,10 @@ dokku neo4j:logs lolipop
 dokku neo4j:logs lolipop -t # to tail
 
 # you can dump the database
-dokku neo4j:export lolipop > lolipop.dump.gz
+dokku neo4j:export lolipop > lolipop.dump
 
 # you can import a dump
-dokku neo4j:import lolipop < database.dump.gz
+dokku neo4j:import lolipop < database.dump
 
 # you can clone an existing database to a new one
 dokku neo4j:clone lolipop new_database

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Unofficial neo4j plugin for dokku. Currently defaults to installing [neo4j 4.0.0
 
 ```shell
 # on 0.12.x+
-sudo dokku plugin:install https://github.com/nampdn/dokku-neo4j.git neo4j
+sudo dokku plugin:install https://github.com/nampdn/dokku-neo4j.git --name neo4j
 ```
 
 ## commands

--- a/common-functions
+++ b/common-functions
@@ -187,8 +187,10 @@ service_backup() {
     dokku_log_fail "Provide AWS credentials or use the --use-iam flag"
   fi
 
-  TMPDIR=$(mktemp -d)
+  # Create the temp dir in the DOKKU_ROOT, ie /home/dokku, so we can also retreive it when running Dokku as container
+  TMPDIR=$(mktemp -d -p "$DOKKU_ROOT")
   trap 'rm -rf "$TMPDIR" > /dev/null' RETURN INT TERM EXIT
+
 
   docker inspect "$ID" &>/dev/null || dokku_log_fail "Service container does not exist"
   is_container_status "$ID" "Running" || dokku_log_fail "Service container is not running"
@@ -198,7 +200,22 @@ service_backup() {
   # Build parameter list for s3backup tool
   BACKUP_PARAMETERS="$BACKUP_PARAMETERS -e BUCKET_NAME=$BUCKET_NAME"
   BACKUP_PARAMETERS="$BACKUP_PARAMETERS -e BACKUP_NAME=${PLUGIN_COMMAND_PREFIX}-${SERVICE}"
-  BACKUP_PARAMETERS="$BACKUP_PARAMETERS -v ${TMPDIR}:/backup"
+  # BACKUP_PARAMETERS="$BACKUP_PARAMETERS -v ${TMPDIR}:/backup"
+
+  # Need to build the correct mount path. If Dokku is not running as a container itself 
+  # then $DOKKU_ROOT == $DOKKU_HOST_ROOT, so the following code would not change anything to the source 
+  # mount path. However, if Dokku is running as container $DOKKU_HOST_ROOT should be set as env variable during startup,
+  # to point to the absolute path on the host running the containers 
+  
+  # Remove the DOKKU_ROOT prefix from the TMPDIR
+  TMPDIR_HOST_INTERMEDIATE="${TMPDIR#"$DOKKU_ROOT"}"
+  
+  # Prepent the DOKKU_HOST_ROOT to the tmp dir, this we can use as mount point for a new container
+  TMPDIR_HOST="${DOKKU_HOST_ROOT}${TMPDIR_HOST_INTERMEDIATE}"
+
+  # The S3plugin requires the data-to-be-stored in the /backup dir
+  BACKUP_PARAMETERS="$BACKUP_PARAMETERS -v ${TMPDIR_HOST}:/backup"
+
 
   if [[ -f "$SERVICE_BACKUP_ROOT/AWS_DEFAULT_REGION" ]]; then
     BACKUP_PARAMETERS="$BACKUP_PARAMETERS -e AWS_DEFAULT_REGION=$(cat "$SERVICE_BACKUP_ROOT/AWS_DEFAULT_REGION")"
@@ -217,7 +234,8 @@ service_backup() {
   fi
 
   # shellcheck disable=SC2086
-  docker run --rm $BACKUP_PARAMETERS dokku/s3backup:0.10.1
+  #dokku_log_warn "using $BACKUP_PARAMETERS"
+  docker run --rm $BACKUP_PARAMETERS dokku/s3backup:0.12.0
 }
 
 service_backup_auth() {

--- a/config
+++ b/config
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 export NEO4J_IMAGE=${NEO4J_IMAGE:="neo4j"}
-export NEO4J_IMAGE_VERSION=${NEO4J_IMAGE_VERSION:="4.0.0"}
+export NEO4J_IMAGE_VERSION=${NEO4J_IMAGE_VERSION:="4.4.4-community"}
 export NEO4J_ROOT=${NEO4J_ROOT:="$DOKKU_LIB_ROOT/services/neo4j"}
 export NEO4J_HOST_ROOT=${NEO4J_HOST_ROOT:=$NEO4J_ROOT}
 

--- a/functions
+++ b/functions
@@ -111,11 +111,27 @@ service_export() {
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
   local DATABASE_NAME="$(get_database_name "$SERVICE")"
   local PASSWORD="$(service_password "$SERVICE")"
+  local SERVICE_HOST_ROOT="$PLUGIN_DATA_HOST_ROOT/$SERVICE"
 
+  # dokku_log_warn "Stopping database neo4j"
+  # the following can be used with enterprise version, instead of stopping the container
+  # docker exec "$SERVICE_NAME" bash cypher-shell -u neo4j -p "$PASSWORD" -d system "STOP DATABASE neo4j;" >/dev/null 2>/dev/null
+
+  service_stop "$SERVICE" >/dev/null 2>/dev/null
+  
   [[ -n $SSH_TTY ]] && stty -opost
-  docker exec "$SERVICE_NAME" bash -c "mongodump -d $DATABASE_NAME -u \"$SERVICE\" -p \"$PASSWORD\" --authenticationDatabase \"$DATABASE_NAME\" --quiet --gzip --archive 2>/dev/null"
+  # the following can be used with enterprise version, instead of spinning up new container 
+  # docker exec "$SERVICE_NAME" bash -c "neo4j-admin dump --database=neo4j --to=- 2>error2.txt"
+  docker run --entrypoint="/bin/bash" -v "$SERVICE_HOST_ROOT/data:/data" -v "$SERVICE_HOST_ROOT/logs:/logs" --env-file="$SERVICE_ROOT/ENV" --env "NEO4J_AUTH=neo4j/$PASSWORD" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" -c "neo4j-admin dump --database=neo4j --to=- 2>error2.txt"
+
   status=$?
   [[ -n $SSH_TTY ]] && stty opost
+  
+  # dokku_log_warn "Starting database neo4j"
+  service_start "$SERVICE" >/dev/null 2>/dev/null
+
+  # docker exec "$SERVICE_NAME" bash cypher-shell -u neo4j -p "$PASSWORD" -d system "START DATABASE neo4j;" >/dev/null 2>/dev/null
+  
   exit $status
 }
 
@@ -130,7 +146,25 @@ service_import() {
   if [[ -t 0 ]]; then
     dokku_log_fail "No data provided on stdin."
   fi
-  docker exec -i "$SERVICE_NAME" bash -c "mongorestore -u \"$SERVICE\" -p \"$PASSWORD\" --authenticationDatabase \"$DATABASE_NAME\" --gzip --archive --nsFrom '\$db\$.\$coll\$' --nsTo '$DATABASE_NAME.\$coll\$'"
+
+  # A database needs to be stopped before a dump can be made
+  # the following can be used with enterprise version, instead of stopping the container
+  # docker exec "$SERVICE_NAME" bash cypher-shell -u neo4j -p "$PASSWORD" -d system "STOP DATABASE neo4j;" 
+  service_stop "$SERVICE" 
+  
+  
+  dokku_log_verbose_quiet "Loading data into neo4j container"
+  # Run as --user neo4j otherwise te database is made as root and you get AccessDenied error
+  # see https://community.neo4j.com/t/database-offline-and-will-not-restart/27914/5 
+  # --from=- means load from stdin
+  # command for enteprise version:
+  # docker exec --user neo4j -i "$SERVICE_NAME" bash -c "neo4j-admin load --database=neo4j --force --from=-"
+  # -i for reading from stdin
+  docker run --user neo4j --entrypoint="/bin/bash" -i -v "$SERVICE_HOST_ROOT/data:/data" -v "$SERVICE_HOST_ROOT/logs:/logs" --env-file="$SERVICE_ROOT/ENV" --env "NEO4J_ACCEPT_LICENSE_AGREEMENT=yes" --env "NEO4J_AUTH=neo4j/$PASSWORD" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" -c "neo4j-admin load --database=neo4j --force --from=-"   
+
+  # start service again
+  service_start "$SERVICE" 
+  #docker exec "$SERVICE_NAME" bash cypher-shell -u neo4j -p "$PASSWORD" -d system "START DATABASE neo4j;" 
 }
 
 service_start() {


### PR DESCRIPTION
Fix the import and export commands (and thereby also the backup-* commands)
- bumped neo4j version (needed to pipe database dumps via stdin with neo4j-admin)
- stop and start container when dumping/loading because neo4j (community edition) cannot perform this on a running database


Example:
```
dokku neo4j:import neobase < neobase.dump
=====> Stopping container
       Container stopped
       Loading data into neo4j container
Selecting JVM - Version:11.0.14.1+1, Name:OpenJDK 64-Bit Server VM, Vendor:Oracle Corporation

Files: 1/36, data:  0.0%
Files: 36/36, data: 100.0%
Done: 36 files, 250.9MiB processed.
=====> Starting container
=====> Container started
```

